### PR TITLE
Refresh on audiosource switch, hide visualizer on mute

### DIFF
--- a/Skins/Fountain of Colors/daemon.ini
+++ b/Skins/Fountain of Colors/daemon.ini
@@ -1,0 +1,42 @@
+[Rainmeter]
+@Include=#@#Variables.inc
+
+[BarH]
+Measure=Calc
+Formula=#BarHeight#
+
+[MeasureWin7Audio]
+Measure=Plugin
+Plugin=Win7AudioPlugin
+
+[DetectDefaultDevice]
+Measure=String
+String=[MeasureWin7Audio]
+OnChangeAction=[!RefreshGroup FountainOfColors]
+DynamicVariables=1
+
+[MeasureAudioLevel]
+Measure=Plugin
+Plugin=AudioLevelBeta
+
+[MeasureRMS]
+Measure=Plugin
+Plugin=AudioLevelBeta
+Parent=MeasureAudioLevel
+Channel=Sum
+Type=RMS
+
+[mRMS]
+Measure=Calc
+Formula=MeasureRMS
+
+[BarAudioMute]
+Measure=Calc
+Formula=mRMS
+IfCondition=(BarAudioMute<=0.0001)
+IfTrueAction=[!WriteKeyValue Variables BarHeight 0 "#@#Variables.inc"][!RefreshGroup FountainOfColors]
+IfFalseAction=[!WriteKeyValue Variables BarHeight [BarH] "#@#Variables.inc"][!RefreshGroup FountainOfColors]
+DynamicVariables=1
+
+[MeterDummy]
+Meter=String


### PR DESCRIPTION
Added a daemon to detect audio source changes using Win7AudioPlugin and refresh the skin group. Hiding the Visualizer by changing bar height depending on RMS value from the included AudioLevelBeta plugin.