### PR TITLE
feat: control Sensitivity by mouse scroll

### DIFF
--- a/Skins/Fountain of Colors/Assist/MouseScroll.ini
+++ b/Skins/Fountain of Colors/Assist/MouseScroll.ini
@@ -1,0 +1,43 @@
+[\]
+@Include=#@#Variables.inc
+
+[Rainmeter]
+Update=100
+BackgroundMode=2
+SolidColor=0,0,0,1
+Group=FountainOfColors
+
+[Variables]
+CaptureAlpha=128
+
+[MeasureMainConfigX]
+Measure=Plugin
+Plugin=ConfigActive
+Config=Fountain of Colors
+InfoType=X
+
+[MeasureMainConfigY]
+Measure=Plugin
+Plugin=ConfigActive
+Config=Fountain of Colors
+InfoType=Y
+
+[MeasureVisualizerWidth]
+Measure=Calc
+Formula=((#Bands#-1)*(#BarWidth#+#BarGap#)+#BarWidth#)
+DynamicVariables=1
+
+[MeasureVisualizerHeight]
+Measure=Calc
+Formula=#BarHeight#
+DynamicVariables=1
+
+[MeterScrollCapture]
+Meter=Shape
+X=0
+Y=0
+Shape=Rectangle 0,0,([MeasureVisualizerWidth]*0.7),([MeasureVisualizerHeight]/2) | Fill Color 255,255,255,#CaptureAlpha# | StrokeWidth 0
+DynamicVariables=1
+MouseScrollUpAction=[!WriteKeyValue Variables Sensitivity "(Clamp(#Sensitivity#+5, 1, 100))" "#@#Variables.inc"][!SetVariable Sensitivity "(Clamp(#Sensitivity#+5, 1, 100))"][!SetOption Audio Sensitivity "(Clamp(#Sensitivity#+5, 1, 100))" "Fountain of Colors"][!UpdateMeasure Audio "Fountain of Colors"]
+MouseScrollDownAction=[!WriteKeyValue Variables Sensitivity "(Clamp(#Sensitivity#-5, 1, 100))" "#@#Variables.inc"][!SetVariable Sensitivity "(Clamp(#Sensitivity#-5, 1, 100))"][!SetOption Audio Sensitivity "(Clamp(#Sensitivity#-5, 1, 100))" "Fountain of Colors"][!UpdateMeasure Audio "Fountain of Colors"]
+MiddleMouseUpAction=[!SetVariable CaptureAlpha "(#CaptureAlpha#=128?1:128)"][!UpdateMeter MeterScrollCapture][!Redraw]

--- a/Skins/Fountain of Colors/Assist/MouseScroll.ini
+++ b/Skins/Fountain of Colors/Assist/MouseScroll.ini
@@ -9,6 +9,7 @@ Group=FountainOfColors
 
 [Variables]
 CaptureAlpha=128
+Step=2
 
 [MeasureMainConfigX]
 Measure=Plugin
@@ -38,6 +39,6 @@ X=0
 Y=0
 Shape=Rectangle 0,0,([MeasureVisualizerWidth]*0.7),([MeasureVisualizerHeight]/2) | Fill Color 255,255,255,#CaptureAlpha# | StrokeWidth 0
 DynamicVariables=1
-MouseScrollUpAction=[!WriteKeyValue Variables Sensitivity "(Clamp(#Sensitivity#+5, 1, 100))" "#@#Variables.inc"][!SetVariable Sensitivity "(Clamp(#Sensitivity#+5, 1, 100))"][!SetOption Audio Sensitivity "(Clamp(#Sensitivity#+5, 1, 100))" "Fountain of Colors"][!UpdateMeasure Audio "Fountain of Colors"]
-MouseScrollDownAction=[!WriteKeyValue Variables Sensitivity "(Clamp(#Sensitivity#-5, 1, 100))" "#@#Variables.inc"][!SetVariable Sensitivity "(Clamp(#Sensitivity#-5, 1, 100))"][!SetOption Audio Sensitivity "(Clamp(#Sensitivity#-5, 1, 100))" "Fountain of Colors"][!UpdateMeasure Audio "Fountain of Colors"]
+MouseScrollUpAction=[!WriteKeyValue Variables Sensitivity "(Clamp(#Sensitivity#+#Step#, 1, 100))" "#@#Variables.inc"][!SetVariable Sensitivity "(Clamp(#Sensitivity#+#Step#, 1, 100))"][!SetOption Audio Sensitivity "(Clamp(#Sensitivity#+#Step#, 1, 100))" "Fountain of Colors"][!UpdateMeasure Audio "Fountain of Colors"]
+MouseScrollDownAction=[!WriteKeyValue Variables Sensitivity "(Clamp(#Sensitivity#-#Step#, 1, 100))" "#@#Variables.inc"][!SetVariable Sensitivity "(Clamp(#Sensitivity#-#Step#, 1, 100))"][!SetOption Audio Sensitivity "(Clamp(#Sensitivity#-#Step#, 1, 100))" "Fountain of Colors"][!UpdateMeasure Audio "Fountain of Colors"]
 MiddleMouseUpAction=[!SetVariable CaptureAlpha "(#CaptureAlpha#=128?1:128)"][!UpdateMeter MeterScrollCapture][!Redraw]


### PR DESCRIPTION
Hello, alatsombath

Thank you for sharing this excellent skin. I've been using it for several years now and it has been fantastic.

I'd like to propose an enhancement based on my personal workflow. After configuring the position and bar settings, I typically enable "Click through" and disable "Draggable" for `Fountain of Colors.ini` to prevent accidentally triggering the settings panel.

However, in this configuration, I frequently need to adjust the Sensitivity value when lowering system volume at night.   
After experimenting with multiple approaches locally, I believe the solution in this PR offers the best balance of functionality and minimal code changes.

Here's a demo showing the mouse wheel interactions (please note the middle mouse button operations):

<img src="https://img.comicguispider.nyc.mn/file/fork/1765879958685_MiddleMouse.gif" height="400">

Best regards